### PR TITLE
Allow return values to indicate that you want the default animation

### DIFF
--- a/app/src/main/java/com/ovenbits/quickactionview/sample/CustomActionsInAnimator.java
+++ b/app/src/main/java/com/ovenbits/quickactionview/sample/CustomActionsInAnimator.java
@@ -24,21 +24,23 @@ public class CustomActionsInAnimator implements ActionsInAnimator {
     }
 
     @Override
-    public void animateActionIn(Action action, int index, ActionView view, Point center) {
+    public boolean animateActionIn(Action action, int index, ActionView view, Point center) {
         view.animate()
                 .alpha(1.0f)
                 .setDuration(200)
                 .setInterpolator(mInterpolator);
+        return true;
     }
 
     @Override
-    public void animateIndicatorIn(View indicator) {
+    public boolean animateIndicatorIn(View indicator) {
         indicator.setAlpha(0);
         indicator.animate().alpha(1).setDuration(200);
+        return true;
     }
 
     @Override
-    public void animateScrimIn(View scrim) {
+    public boolean animateScrimIn(View scrim) {
         Point center = mQuickActionView.getCenterPoint();
         if (Build.VERSION.SDK_INT >= 21 && center != null) {
             ViewAnimationUtils.createCircularReveal(scrim, center.x, center.y, 0, Math.max(scrim.getHeight(), scrim.getWidth()))
@@ -47,5 +49,6 @@ public class CustomActionsInAnimator implements ActionsInAnimator {
             scrim.setAlpha(0f);
             scrim.animate().alpha(1f).setDuration(200);
         }
+        return true;
     }
 }

--- a/quickactionview/src/main/java/com/ovenbits/quickactionview/ActionsInAnimator.java
+++ b/quickactionview/src/main/java/com/ovenbits/quickactionview/ActionsInAnimator.java
@@ -14,18 +14,21 @@ public interface ActionsInAnimator {
      * @param index the index of the action in the list of actions
      * @param view the action view to animate
      * @param center the final resting center point of the Action
+     * @return true if you are overriding animation, false if you want the default animation
      */
-    void animateActionIn(Action action, int index, ActionView view, Point center);
+    boolean animateActionIn(Action action, int index, ActionView view, Point center);
 
     /**
      * Animate in the indicator as the QuickActionView shows
      * @param indicator the indicator view
+     * @return true if you are overriding animation, false if you want the default animation
      */
-    void animateIndicatorIn(View indicator);
+    boolean animateIndicatorIn(View indicator);
 
     /**
      * Animate in the scrim as the QuickActionView shows
      * @param scrim the scrim view
+     * @return true if you are overriding animation, false if you want the default animation
      */
-    void animateScrimIn(View scrim);
+    boolean animateScrimIn(View scrim);
 }

--- a/quickactionview/src/main/java/com/ovenbits/quickactionview/ActionsOutAnimator.java
+++ b/quickactionview/src/main/java/com/ovenbits/quickactionview/ActionsOutAnimator.java
@@ -14,21 +14,21 @@ public interface ActionsOutAnimator {
      * @param index The position of the actionview in its parent
      * @param view The action view
      * @param center The center of the indicator
-     * @return The duration of this animation, in milliseconds
+     * @return The duration of this animation, in milliseconds. Passing -1 indicates you want the default animation to play
      */
     int animateActionOut(Action action, int index, ActionView view, Point center);
 
     /**
      * Animate the indicator view as the QuickActionView dismisses
      * @param indicator The indicator view
-     * @return The duration of this animation, in milliseconds
+     * @return The duration of this animation, in milliseconds. Passing -1 indicates you want the default animation to play
      */
     int animateIndicatorOut(View indicator);
 
     /**
      * Animate the scrim as the QuickActionView dismisses
      * @param scrim The scrimView to animate
-     * @return The duration of this animation, in milliseconds
+     * @return The duration of this animation, in milliseconds. Passing -1 indicates you want the default animation to play
      */
     int animateScrimOut(View scrim);
 

--- a/quickactionview/src/main/java/com/ovenbits/quickactionview/animator/FadeAnimator.java
+++ b/quickactionview/src/main/java/com/ovenbits/quickactionview/animator/FadeAnimator.java
@@ -17,23 +17,26 @@ public class FadeAnimator implements ActionsInAnimator, ActionsOutAnimator {
     private LinearInterpolator mInterpolator = new LinearInterpolator();
 
     @Override
-    public void animateActionIn(Action action, int index, ActionView view, Point center) {
+    public boolean animateActionIn(Action action, int index, ActionView view, Point center) {
         view.animate()
                 .alpha(1.0f)
                 .setDuration(200)
                 .setInterpolator(mInterpolator);
+        return true;
     }
 
     @Override
-    public void animateIndicatorIn(View indicator) {
+    public boolean animateIndicatorIn(View indicator) {
         indicator.setAlpha(0);
         indicator.animate().alpha(1).setDuration(200);
+        return true;
     }
 
     @Override
-    public void animateScrimIn(View scrim) {
+    public boolean animateScrimIn(View scrim) {
         scrim.setAlpha(0f);
         scrim.animate().alpha(1f).setDuration(200);
+        return true;
     }
 
     @Override

--- a/quickactionview/src/main/java/com/ovenbits/quickactionview/animator/PopAnimator.java
+++ b/quickactionview/src/main/java/com/ovenbits/quickactionview/animator/PopAnimator.java
@@ -27,7 +27,7 @@ public class PopAnimator implements ActionsInAnimator, ActionsOutAnimator {
     }
 
     @Override
-    public void animateActionIn(Action action, int index, ActionView view, Point center) {
+    public boolean animateActionIn(Action action, int index, ActionView view, Point center) {
         view.setScaleX(0.01f);
         view.setScaleY(0.01f);
         ViewPropertyAnimator viewPropertyAnimator = view.animate().scaleY(1.0f)
@@ -37,18 +37,21 @@ public class PopAnimator implements ActionsInAnimator, ActionsOutAnimator {
         if (mStaggered) {
             viewPropertyAnimator.setStartDelay(index * 100);
         }
+        return true;
     }
 
     @Override
-    public void animateIndicatorIn(View indicator) {
+    public boolean animateIndicatorIn(View indicator) {
         indicator.setAlpha(0);
         indicator.animate().alpha(1).setDuration(200);
+        return true;
     }
 
     @Override
-    public void animateScrimIn(View scrim) {
+    public boolean animateScrimIn(View scrim) {
         scrim.setAlpha(0f);
         scrim.animate().alpha(1f).setDuration(200);
+        return true;
     }
 
     @Override

--- a/quickactionview/src/main/java/com/ovenbits/quickactionview/animator/SlideFromCenterAnimator.java
+++ b/quickactionview/src/main/java/com/ovenbits/quickactionview/animator/SlideFromCenterAnimator.java
@@ -28,7 +28,7 @@ public class SlideFromCenterAnimator implements ActionsInAnimator, ActionsOutAni
     }
 
     @Override
-    public void animateActionIn(Action action, int index, ActionView view, Point center) {
+    public boolean animateActionIn(Action action, int index, ActionView view, Point center) {
         Point actionCenter = view.getCircleCenterPoint();
         actionCenter.offset(view.getLeft(), view.getTop());
         view.setTranslationY(center.y - actionCenter.y);
@@ -41,18 +41,21 @@ public class SlideFromCenterAnimator implements ActionsInAnimator, ActionsOutAni
         if (mStaggered) {
             viewPropertyAnimator.setStartDelay(index * 100);
         }
+        return true;
     }
 
     @Override
-    public void animateIndicatorIn(View indicator) {
+    public boolean animateIndicatorIn(View indicator) {
         indicator.setAlpha(0);
         indicator.animate().alpha(1).setDuration(200);
+        return true;
     }
 
     @Override
-    public void animateScrimIn(View scrim) {
+    public boolean animateScrimIn(View scrim) {
         scrim.setAlpha(0);
         scrim.animate().alpha(1).setDuration(200);
+        return true;
     }
 
     @Override


### PR DESCRIPTION
Basically right now, if you were to create an ActionInAnimator or an ActionsOutAnimator, you would be forced to implement each of the animations. This would allow you to return false on an ActionsInAnimator on a method that you do not want to override, and return -1 on the ActionsOutAnimator to indicate the default out animation. 

Since this would break all animators created with 1.0, it should probably be a 1.1 bump